### PR TITLE
Harden Hangman storage bootstrap and cache token wiring

### DIFF
--- a/hangman.HTML
+++ b/hangman.HTML
@@ -4,12 +4,12 @@
 <meta charset="utf-8">
 <title>Hangman</title>
 <script>
-  location.replace('hangman.html?v=2026-04-26-1');
+  location.replace('hangman.html?v=2026-04-27-1');
 </script>
-<meta http-equiv="refresh" content="0; url=hangman.html?v=2026-04-26-1">
+<meta http-equiv="refresh" content="0; url=hangman.html?v=2026-04-27-1">
 <link rel="canonical" href="hangman.html">
 </head>
 <body>
-<a href="hangman.html?v=2026-04-26-1">Click here if not redirected</a>
+<a href="hangman.html?v=2026-04-27-1">Click here if not redirected</a>
 </body>
 </html>

--- a/hangman.html
+++ b/hangman.html
@@ -10,7 +10,7 @@
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="theme-color" content="#f4efe6">
 <meta name="format-detection" content="telephone=no">
-<link rel="manifest" href="manifest.webmanifest?v=2026-04-26-1">
+<link rel="manifest" href="manifest.webmanifest?v=2026-04-27-1">
 <title>Hangman</title>
 <style>
 @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;600;700&family=Space+Mono:wght@400;700&display=swap');
@@ -257,9 +257,9 @@ html,body{height:100%;height:100dvh;width:100%;overflow:hidden;font-family:'Cave
 </div>
 
 <script>
-const APP_VERSION="1.3.0"
-const APP_BUILD_DATE="Apr 26, 2026"
-const APP_CACHE_TOKEN="2026-04-26-1"
+const APP_VERSION="1.3.1"
+const APP_BUILD_DATE="Apr 27, 2026"
+const APP_CACHE_TOKEN="2026-04-27-1"
 const isStandalone=window.matchMedia("(display-mode: standalone)").matches||window.navigator.standalone===true
 
 // Normalize launch URL for home-screen installs so stale bookmarked query strings
@@ -292,6 +292,12 @@ const safeStorage=(()=>{
   }
 })()
 
+const STORAGE_KEYS={
+  lists:"hangmanLists",
+  activeList:"hangmanActiveList",
+  exploreMode:"exploreMode"
+}
+
 function readJSON(key,fallback){
   try{
     const value=safeStorage.getItem(key)
@@ -301,16 +307,32 @@ function readJSON(key,fallback){
   }
 }
 
-let lists=readJSON("hangmanLists",{})
-if(!lists.default)lists.default=DEFAULT_LIST
-if(!lists.cars)lists.cars=CAR_BRANDS
+function normalizeWordArray(value,fallback){
+  if(!Array.isArray(value))return fallback.slice()
+  return Array.from(new Set(value.map(w=>String(w||"").trim().toUpperCase()).filter(Boolean)))
+}
 
-let currentListName=safeStorage.getItem("hangmanActiveList")||"default"
+function normalizeLists(value){
+  const source=value&&typeof value==="object"?value:{}
+  const normalized={}
+  for(const [name,words] of Object.entries(source)){
+    const clean=normalizeWordArray(words,[])
+    if(clean.length)normalized[name]=clean
+  }
+  if(!normalized.default)normalized.default=DEFAULT_LIST.slice()
+  if(!normalized.cars)normalized.cars=CAR_BRANDS.slice()
+  return normalized
+}
+
+let lists=normalizeLists(readJSON(STORAGE_KEYS.lists,{}))
+safeStorage.setItem(STORAGE_KEYS.lists,JSON.stringify(lists))
+
+let currentListName=safeStorage.getItem(STORAGE_KEYS.activeList)||"default"
 
 function getWords(){
   if(!Array.isArray(lists[currentListName])){
     currentListName="default"
-    safeStorage.setItem("hangmanActiveList",currentListName)
+    safeStorage.setItem(STORAGE_KEYS.activeList,currentListName)
   }
   return lists[currentListName]
 }
@@ -574,7 +596,7 @@ function renderWords(){
     btn.setAttribute("aria-label","Remove word "+w)
     btn.addEventListener("click",()=>{
       lists[currentListName]=lists[currentListName].filter(x=>x!==w)
-      safeStorage.setItem("hangmanLists",JSON.stringify(lists))
+      safeStorage.setItem(STORAGE_KEYS.lists,JSON.stringify(lists))
       root=buildRoot()
       curNode=root
       refreshSettings()
@@ -599,9 +621,14 @@ function renderDepthStats(){
   document.getElementById("depthStats").innerHTML=html
 }
 
+const listSelect=document.getElementById("listSelect")
+const useList=document.getElementById("useList")
+const addWordInput=document.getElementById("addWordInput")
+const createListBtn=document.getElementById("createListBtn")
+
 useList.addEventListener("click",()=>{
   currentListName=listSelect.value
-  safeStorage.setItem("hangmanActiveList",currentListName)
+  safeStorage.setItem(STORAGE_KEYS.activeList,currentListName)
   root=buildRoot()
   curNode=root
   refreshSettings()
@@ -612,7 +639,7 @@ addWordInput.addEventListener("keydown",e=>{
   const w=e.target.value.trim().toUpperCase()
   if(!w)return
   if(!lists[currentListName].includes(w))lists[currentListName].push(w)
-  safeStorage.setItem("hangmanLists",JSON.stringify(lists))
+  safeStorage.setItem(STORAGE_KEYS.lists,JSON.stringify(lists))
   root=buildRoot()
   curNode=root
   strokes=[]
@@ -629,7 +656,7 @@ createListBtn.addEventListener("click",()=>{
   const words=raw.split("\n").map(w=>w.trim().toUpperCase()).filter(w=>w.length>0)
   if(words.length===0)return
   lists[name]=Array.from(new Set(words))
-  safeStorage.setItem("hangmanLists",JSON.stringify(lists))
+  safeStorage.setItem(STORAGE_KEYS.lists,JSON.stringify(lists))
   document.getElementById("newListName").value=""
   document.getElementById("newListWords").value=""
   refreshSettings()
@@ -642,7 +669,7 @@ let exploreNode=null
 let exploreWords=[]
 
 const EXPLORE_ON="1"
-function isExploreModeEnabled(){return safeStorage.getItem("exploreMode")===EXPLORE_ON}
+function isExploreModeEnabled(){return safeStorage.getItem(STORAGE_KEYS.exploreMode)===EXPLORE_ON}
 
 function pluralWords(n){return n+" word"+(n!==1?"s":"")}
 function syncExploreButton(){
@@ -652,7 +679,7 @@ function syncExploreButton(){
 const exploreModeToggle=document.getElementById("exploreModeToggle")
 exploreModeToggle.checked=isExploreModeEnabled()
 exploreModeToggle.addEventListener("change",()=>{
-  safeStorage.setItem("exploreMode",exploreModeToggle.checked?EXPLORE_ON:"0")
+  safeStorage.setItem(STORAGE_KEYS.exploreMode,exploreModeToggle.checked?EXPLORE_ON:"0")
   syncExploreButton()
 })
 syncExploreButton()

--- a/index.html
+++ b/index.html
@@ -4,16 +4,16 @@
 <meta charset="utf-8">
 <title>Hangman</title>
 <script>
-  const APP_VERSION = '2026-04-26-1';
+  const APP_VERSION = '2026-04-27-1';
   const target = `hangman.html?v=${APP_VERSION}`;
   if (location.pathname.endsWith('/index.html') || location.pathname.endsWith('/')) {
     location.replace(target);
   }
 </script>
 <link rel="canonical" href="hangman.html">
-<meta http-equiv="refresh" content="0; url=hangman.html?v=2026-04-26-1">
+<meta http-equiv="refresh" content="0; url=hangman.html?v=2026-04-27-1">
 </head>
 <body>
-<a href="hangman.html?v=2026-04-26-1">Click here if not redirected</a>
+<a href="hangman.html?v=2026-04-27-1">Click here if not redirected</a>
 </body>
 </html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Hangman",
   "short_name": "Hangman",
-  "start_url": "hangman.html?v=2026-04-26-1",
+  "start_url": "hangman.html?v=2026-04-27-1",
   "scope": "./",
   "display": "standalone",
   "background_color": "#f4efe6",


### PR DESCRIPTION
### Motivation
- Fix intermittent runtime breakage caused by stale or malformed persisted list data and by relying on browser-global DOM id bindings, while preserving the app's look and behavior.

### Description
- Introduced `STORAGE_KEYS` and centralized storage key usage and rewrites to avoid drift between code paths.
- Added `normalizeWordArray` and `normalizeLists` to sanitize cached list data on startup and immediately persist a cleaned state back to storage via `safeStorage`.
- Replaced implicit ID globals with explicit `document.getElementById` bindings for settings controls (`listSelect`, `useList`, `addWordInput`, `createListBtn`) to prevent browser-dependent failures.
- Bumped cache/version tokens (`APP_VERSION`, `APP_BUILD_DATE`, `APP_CACHE_TOKEN`) and synced the `v` token in `index.html`, `hangman.HTML`, `hangman.html`, and `manifest.webmanifest` so fresh builds resolve consistently.

### Testing
- Ran `python -m json.tool manifest.webmanifest` to validate the manifest JSON, which succeeded.
- Searched code to verify storage keys and cache token rewrites with `rg -n "hangmanActiveList|hangmanLists|exploreMode|APP_VERSION|APP_BUILD_DATE|2026-04-27-1|2026-04-26-1"`, which confirmed the expected replacements.
- Reviewed diffs with `git status`/`git diff` and committed the change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff797da3083328f4a7d3b5abbbad8)