### PR TITLE
Integrate updated Hangman implementation with UI, decision-tree and depth analytics

### DIFF
--- a/hangman.html
+++ b/hangman.html
@@ -1,874 +1,553 @@
 <!doctype html>
-
 <html lang="en">
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
-<meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta name="apple-mobile-web-app-title" content="Hangman">
-<meta name="mobile-web-app-capable" content="yes">
-<meta name="theme-color" content="#f4efe6">
-<meta name="format-detection" content="telephone=no">
-<link rel="manifest" href="manifest.webmanifest?v=2026-04-28-1">
 <title>Hangman</title>
 <style>
 @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;600;700&family=Space+Mono:wght@400;700&display=swap');
-
 :root{--bg:#f4efe6;--paper:#f8f4ec;--ink:#1a1814;--faint:#cfc6b6;--toolbar:#ece6dc}
-
 *{box-sizing:border-box;-webkit-tap-highlight-color:transparent;margin:0;padding:0}
-
-html,body{width:100%;height:100%;overflow:hidden;font-family:'Caveat',cursive;background:#ddd}
-
-#frame{
-  position:fixed;
-  inset:0;
-  height:100dvh;
-  background:#e9e3d7;
-  padding:calc(env(safe-area-inset-top) + 10px) calc(env(safe-area-inset-right) + 10px) 10px calc(env(safe-area-inset-left) + 10px);
-}
-
-#app{
-  height:100%;
-  width:100%;
-  display:flex;
-  flex-direction:column;
-  min-height:0;
-  background:var(--bg);
-  border-radius:10px;
-  border:2px solid rgba(0,0,0,.35);
-  box-shadow:0 4px 12px rgba(0,0,0,.12);
-  overflow:hidden;
-}
-
-#canvasWrap{flex:1 1 auto;min-height:0;position:relative}
-
-#drawCanvas{position:absolute;inset:0;width:100%;height:100%;display:block;cursor:crosshair;touch-action:none;background:linear-gradient(var(--paper),var(--paper))}
-
-#toolbar{background:linear-gradient(var(--toolbar),#e6dfd3);border-top:1px solid var(--faint);display:flex;align-items:center;justify-content:space-around;padding:10px 8px 10px;flex-shrink:0;min-height:70px}
-
+html,body{height:100%;width:100%;overflow:hidden;font-family:'Caveat',cursive;background:#ddd}
+#frame{position:fixed;inset:0;padding:10px;background:#e9e3d7}
+#app{width:100%;height:100%;display:flex;flex-direction:column;background:var(--bg);border-radius:10px;border:2px solid rgba(0,0,0,.35);box-shadow:0 4px 12px rgba(0,0,0,.12);position:relative;overflow:hidden}
+#drawCanvas{flex:1;width:100%;display:block;cursor:crosshair;touch-action:none;background:linear-gradient(var(--paper),var(--paper))}
+#toolbar{height:56px;background:linear-gradient(var(--toolbar),#e6dfd3);border-top:1px solid var(--faint);display:flex;align-items:center;justify-content:space-around;padding:0 8px;flex-shrink:0}
 .tool-btn{font-family:'Space Mono',monospace;font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;background:#f7f2e8;border:1px solid var(--faint);border-radius:10px;padding:7px 13px;color:#6f6a61;cursor:pointer}
-
-.tool-btn.active{background:var(--ink);color:#1a1814;border-color:var(--ink)}
-
+.tool-btn.active{background:var(--ink);color:#fff8ee;border-color:var(--ink)}
 #peek{position:absolute;bottom:0;right:2px;font-family:'Space Mono',monospace;font-size:10px;font-weight:700;letter-spacing:.04em;opacity:0;pointer-events:none;color:#666}
-
 #peek.show{opacity:1}
-
 #perfDot{position:absolute;bottom:2px;left:8px;font-family:'Space Mono',monospace;font-size:14px;color:#666;opacity:0}
-
 #perfDot.show{opacity:.9}
-
-#debugBadge{position:absolute;top:6px;left:6px;z-index:50;font-family:'Space Mono',monospace;font-size:10px;line-height:1.3;color:#222;background:rgba(255,255,255,.9);border:1px solid #bdb4a7;border-radius:8px;padding:4px 6px;display:none;white-space:pre-line}
-
-#debugBadge.show{display:block}
-
-#settingsPanel{position:fixed;inset:0;background:#f4efe6;display:none;flex-direction:column;overflow:auto;padding:max(24px,env(safe-area-inset-top)) max(24px,env(safe-area-inset-right)) 24px max(24px,env(safe-area-inset-left));z-index:500}
-
+#settingsPanel{position:fixed;inset:0;background:#f4efe6;display:none;flex-direction:column;overflow:auto;padding:24px;z-index:500}
 #settingsHeader{display:flex;justify-content:space-between;align-items:center;margin-bottom:20px}
-
 #settingsHeader h1{font-family:'Space Mono',monospace;font-size:16px}
-
 #closeSettings{font-family:'Space Mono',monospace;font-size:12px;padding:6px 10px}
-
 .section{margin-bottom:28px}
-
 .section h2{font-family:'Space Mono',monospace;font-size:14px;margin-bottom:8px}
-
-#wordView{font-family:monospace;font-size:12px;background:white;border:1px solid #ccc;padding:8px;max-height:200px;overflow:auto}
-
+#wordView{font-family:monospace;font-size:12px;white-space:pre-wrap;background:white;border:1px solid #ccc;padding:8px;max-height:200px;overflow:auto}
 #depthStats{font-family:monospace;font-size:12px;margin-top:8px;background:white;border:1px solid #ccc;padding:8px}
-
 #firstLetter{font-family:monospace;font-size:12px;margin-top:6px;background:white;border:1px solid #ccc;padding:6px;display:inline-block}
-
 #addWordInput{width:100%;padding:6px;margin-top:6px;font-family:monospace}
-
 #newListName{width:100%;padding:6px;margin-top:6px;font-family:monospace}
-
 #newListWords{width:100%;height:140px;padding:6px;margin-top:6px;font-family:monospace}
-
+#depthChart{font-family:'Space Mono',monospace;background:white;border:1px solid #ccc;border-radius:8px;padding:10px;margin-top:8px}
+.chartIntro{font-family:'Space Mono',monospace;font-size:11px;color:#777;line-height:1.35;margin-bottom:10px}
+.depthBarRow{display:grid;grid-template-columns:64px 1fr 42px;gap:8px;align-items:center;margin:7px 0;cursor:pointer}
+.depthBarRow.selected .depthBar{outline:2px solid var(--ink)}
+.depthLabel{font-size:11px;color:#555;text-align:right}
+.depthBarTrack{height:22px;background:#eee8df;border-radius:8px;overflow:hidden;border:1px solid #ddd2c2}
+.depthBar{height:100%;background:#6f6a61;min-width:2px;border-radius:7px}
+.depthCount{font-size:11px;color:#555;text-align:left}
+#depthWords{font-family:monospace;font-size:12px;background:white;border:1px solid #ccc;border-radius:8px;padding:8px;margin-top:10px;max-height:150px;overflow:auto}
+#patternFilter{font-family:'Space Mono',monospace;background:white;border:1px solid #ccc;border-radius:8px;padding:10px;margin-top:12px}
+.filterGrid{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:8px}
+.filterGrid label{font-size:11px;color:#555;display:flex;flex-direction:column;gap:4px}
+.filterGrid input{padding:5px;font-family:'Space Mono',monospace;font-size:12px;width:100%;border:1px solid #ccc;border-radius:6px}
+#patternWords{font-family:monospace;font-size:12px;background:white;border:1px solid #ccc;border-radius:8px;padding:8px;margin-top:8px;max-height:150px;overflow:auto}
+.depthWordChip{display:inline-block;background:#eee8df;border-radius:5px;padding:2px 6px;margin:2px}
 #helpOverlay{position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;z-index:999}
-
-#helpOverlay .line{position:absolute;left:0;right:0;border-top:2px dashed #fff}
-
-#helpOverlay .box{position:absolute;border:2px solid red;border-radius:8px}
-
 #helpOverlay .content{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:90%;max-width:420px;max-height:80vh;overflow:auto;color:#fff;font-family:'Space Mono',monospace;font-size:13px;line-height:1.6;background:rgba(0,0,0,.6);padding:18px;border-radius:14px}
-
 #helpOverlay button{position:absolute;top:16px;right:16px}
-
-.mono-caption{font-family:'Space Mono',monospace;font-size:10px;color:#999}
-
-.mt-2{margin-top:2px}
-
-.mt-6{margin-top:6px}
-
-.toggle-label{font-family:'Space Mono',monospace;font-size:12px;display:flex;align-items:center;gap:8px;cursor:pointer}
-
-.toggle-checkbox{width:16px;height:16px;cursor:pointer}
-
-.word-row{display:flex;justify-content:space-between;align-items:center;padding:2px 0;border-bottom:1px solid #eee}
-
-.word-delete-btn{background:none;border:none;color:#c00;font-size:16px;font-weight:700;cursor:pointer;padding:0 4px;line-height:1;flex-shrink:0}
-
-/* ── Explore Panel ── */
-#explorePanel{position:fixed;inset:0;background:var(--bg);display:none;flex-direction:column;overflow:hidden;z-index:600;padding:max(14px,env(safe-area-inset-top)) max(14px,env(safe-area-inset-right)) 14px max(14px,env(safe-area-inset-left))}
-
-#exploreHeader{display:flex;justify-content:space-between;align-items:center;flex-shrink:0;margin-bottom:10px}
-
-#exploreTitle{font-family:'Space Mono',monospace;font-size:14px;font-weight:700}
-
-#explorePath{font-family:'Space Mono',monospace;font-size:11px;color:#888;min-height:18px;overflow-x:auto;white-space:nowrap;flex-shrink:0;margin-bottom:8px;padding-bottom:2px}
-
-.path-item{display:inline-block;padding:1px 5px;border-radius:4px;background:#e6dfd3;margin:0 1px;font-weight:700}
-
-.path-item.yes{background:#c8eac8;color:#2a6b2a}
-
-.path-item.no{background:#f5c8c8;color:#8b1a1a}
-
-.path-sep{color:#bbb;margin:0 2px}
-
-#exploreQuestion{font-family:'Space Mono',monospace;font-size:20px;font-weight:700;text-align:center;padding:14px 8px;background:#fff;border:2px solid var(--faint);border-radius:12px;flex-shrink:0;margin-bottom:10px;letter-spacing:.04em}
-
-#exploreBranches{display:flex;gap:10px;flex-shrink:0;margin-bottom:10px}
-
-.explore-card{flex:1;background:#fff;border:2px solid var(--faint);border-radius:14px;padding:12px 10px;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:5px;transition:background .15s,border-color .15s;-webkit-tap-highlight-color:transparent;user-select:none}
-
-.explore-card:active{opacity:.75}
-
-.yes-card{border-color:#a0d8a0}
-
-.no-card{border-color:#e8a8a8}
-
-.card-label{font-family:'Space Mono',monospace;font-size:13px;font-weight:700}
-
-.yes-card .card-label{color:#2a6b2a}
-
-.no-card .card-label{color:#8b1a1a}
-
-.card-next{font-family:'Space Mono',monospace;font-size:18px;font-weight:700;color:var(--ink)}
-
-.card-count{font-family:'Space Mono',monospace;font-size:11px;color:#888}
-
-.card-leaf{font-family:'Space Mono',monospace;font-size:12px;color:#555;text-align:center;word-break:break-all}
-
-#exploreWordList{flex:1;overflow-y:auto;background:#fff;border:1px solid var(--faint);border-radius:10px;padding:8px 10px}
-
-.explore-words-header{font-family:'Space Mono',monospace;font-size:11px;color:#888;margin-bottom:6px}
-
-.explore-words-grid{display:flex;flex-wrap:wrap;gap:4px}
-
-.explore-word{font-family:'Space Mono',monospace;font-size:11px;background:#f0ece3;border-radius:4px;padding:2px 6px;color:var(--ink)}
-
-#exploreLeafCard{background:#fff;border:2px solid #a0d8a0;border-radius:14px;padding:18px;text-align:center;flex-shrink:0;margin-bottom:10px;display:none}
-
-#exploreLeafCard .leaf-label{font-family:'Space Mono',monospace;font-size:11px;color:#888;margin-bottom:4px}
-
-#exploreLeafCard .leaf-word{font-family:'Space Mono',monospace;font-size:22px;font-weight:700;color:var(--ink);letter-spacing:.06em}
 </style>
-
 </head>
 <body>
 <div id="frame">
-  <div id="app">
-    <div id="canvasWrap">
-      <canvas id="drawCanvas" aria-label="Drawing canvas for hangman input"></canvas>
-    </div>
-    <div id="toolbar" aria-label="Game controls">
-      <button class="tool-btn" id="btnDraw">Draw</button>
-      <button class="tool-btn" id="btnErase">Erase</button>
-      <button class="tool-btn" id="btnUndo">Undo</button>
-      <button class="tool-btn" id="btnClear">Clear</button>
-      <button class="tool-btn" id="btnHangman">Hangman</button>
-      <button class="tool-btn" id="btnSolve">Solve</button>
-      <button class="tool-btn" id="btnExplore" style="display:none">Explore</button>
-    </div>
-    <div id="peek"></div>
-    <div id="perfDot">.</div>
-    <div id="debugBadge" aria-live="polite"></div>
-  </div>
+<div id="app">
+<canvas id="drawCanvas"></canvas>
+<div id="toolbar">
+<button class="tool-btn active" id="btnDraw">Draw</button>
+<button class="tool-btn" id="btnErase">Erase</button>
+<button class="tool-btn" id="btnUndo">Undo</button>
+<button class="tool-btn" id="btnClear">Clear</button>
+<button class="tool-btn" id="btnHangman">Hangman</button>
+<button class="tool-btn" id="btnSolve">Solve</button>
+</div>
+<div id="peek"></div>
+<div id="perfDot">.</div>
+</div>
 </div>
 
-<div id="settingsPanel" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Settings">
-  <div id="settingsHeader">
-    <div><h1>Settings</h1><div class="mono-caption mt-2" id="settingsBuildInfo"></div></div>
-    <button id="closeSettings">Close</button>
-  </div>
-  <div class="section">
-    <h2>Active Word List</h2>
-    <select id="listSelect"></select>
-    <button id="useList">Use Selected</button>
-    <div id="firstLetter"></div>
-  </div>
-  <div class="section">
-    <h2>Create New List</h2>
-    <input id="newListName" placeholder="LIST NAME"/>
-    <textarea id="newListWords" placeholder="PASTE WORDS (ONE PER LINE)"></textarea>
-    <button id="createListBtn">Create List</button>
-  </div>
-  <div class="section">
-    <h2>Add Word To Current List</h2>
-    <input id="addWordInput" placeholder="TYPE WORD AND PRESS ENTER"/>
-  </div>
-  <div class="section">
-    <h2>Words</h2>
-    <div id="wordView"></div>
-  </div>
-  <div class="section">
-    <h2>Decision Depth</h2>
-    <div id="depthStats"></div>
-  </div>
-  <div class="section">
-    <h2>Explore Mode</h2>
-    <label class="toggle-label">
-      <input type="checkbox" id="exploreModeToggle" class="toggle-checkbox">
-      Enable Explore List Mode
-    </label>
-    <div class="mono-caption mt-6">Adds an Explore button to the toolbar for visual tree navigation.</div>
-  </div>
-  <div class="section">
-    <h2>Screenshot Mode</h2>
-    <label class="toggle-label">
-      <input type="checkbox" id="debugBadgeToggle" class="toggle-checkbox">
-      Show build/layout badge
-    </label>
-    <div class="mono-caption mt-6">Use this before taking screenshots so build/version and viewport sizing are visible.</div>
-  </div>
+<div id="settingsPanel">
+<div id="settingsHeader">
+<h1>Settings</h1>
+<button id="closeSettings">Close</button>
+</div>
+<div class="section">
+<h2>Active Word List</h2>
+<select id="listSelect"></select>
+<button id="useList">Use Selected</button>
+<div id="firstLetter"></div>
+</div>
+<div class="section">
+<h2>Create New List</h2>
+<input id="newListName" placeholder="LIST NAME"/>
+<textarea id="newListWords" placeholder="PASTE WORDS (ONE PER LINE)"></textarea>
+<button id="createListBtn">Create List</button>
+</div>
+<div class="section">
+<h2>Add Word To Current List</h2>
+<input id="addWordInput" placeholder="TYPE WORD AND PRESS ENTER"/>
+</div>
+<div class="section">
+<h2>Words</h2>
+<div id="wordView"></div>
+</div>
+<div class="section">
+<h2>Anagram Depth Distribution</h2>
+<div id="depthChart"></div>
+<div id="depthWords">Tap a bar to see which words are at that depth.</div>
+<div id="patternFilter">
+<div class="chartIntro">Filter words by hangman pressure: how many wrong guesses in a row occur before getting a correct letter. Leave blank to ignore.</div>
+<div class="filterGrid">
+<label>Max consecutive incorrect guesses / NOs
+<input id="noRunFilter" type="number" inputmode="numeric" min="0" placeholder="Any"/>
+</label>
+<label>Total correct letters / YESes
+<input id="yesCountFilter" type="number" inputmode="numeric" min="0" placeholder="Any"/>
+</label>
+</div>
+<div id="patternWords">Enter a number to filter matching words.</div>
+</div>
+</div>
+<div class="section">
+<h2>Decision Depth</h2>
+<div id="depthStats"></div>
+</div>
 </div>
 
-
-
-<div id="explorePanel" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Explore list">
-  <div id="exploreHeader">
-    <button class="tool-btn" id="exploreBack">← Back</button>
-    <div id="exploreTitle">Explore List</div>
-    <button class="tool-btn" id="exploreClose">Close</button>
-  </div>
-  <div id="explorePath"></div>
-  <div id="exploreQuestion"></div>
-  <div id="exploreLeafCard">
-    <div class="leaf-label">WORD</div>
-    <div class="leaf-word" id="exploreLeafWord"></div>
-  </div>
-  <div id="exploreBranches">
-    <div class="explore-card yes-card" id="exploreYesCard" role="button" tabindex="0" aria-label="Choose yes branch">
-      <div class="card-label">YES</div>
-      <div class="card-next" id="exploreYesNext"></div>
-      <div class="card-count" id="exploreYesCount"></div>
-      <div class="card-leaf" id="exploreYesLeaf"></div>
-    </div>
-    <div class="explore-card no-card" id="exploreNoCard" role="button" tabindex="0" aria-label="Choose no branch">
-      <div class="card-label">NO</div>
-      <div class="card-next" id="exploreNoNext"></div>
-      <div class="card-count" id="exploreNoCount"></div>
-      <div class="card-leaf" id="exploreNoLeaf"></div>
-    </div>
-  </div>
-  <div id="exploreWordList">
-    <div class="explore-words-header" id="exploreWordsHeader"></div>
-    <div class="explore-words-grid" id="exploreWordsGrid"></div>
-  </div>
+<div id="helpOverlay">
+<div class="content">
+<b>Quick Start</b><br><br>
+• Have them think of an everyday object they’re holding<br>
+• Tap Hangman to start<br>
+• Begin with E — ask if it’s in their word<br><br>
+• If no → draw a hangman part<br>
+• If yes → write it below the gallows<br><br>
+• Location of each input advances anagram accordingly<br>
+• SOLVE = peek next letter (visible only while finger is on screen)<br>
+• Undo = remove last stroke<br><br>
+• Keep going until the word appears<br>
+• Tap SOLVE to reveal, Hangman to reset<br>
+• Double-tap top-right for Settings<br><br>
+Tip: I emphasize that, unlike normal hangman, I don’t know the word length, letter positions, or repeats.
 </div>
-
-<div id="helpOverlay" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Quick start help">
-  <div class="content">
-    <b>Quick Start</b><br><br>
-    • Have them think of an everyday object they're holding<br>
-    • Tap Hangman to start<br>
-    • Begin with E — ask if it's in their word<br><br>
-    • If no → draw a hangman part<br>
-    • If yes → write it below the gallows<br><br>
-    • Location of each input advances anagram accordingly<br>
-    • SOLVE = peek next letter (visible only while finger is on screen)<br>
-    • Undo = remove last stroke<br><br>
-    • Keep going until the word appears<br>
-    • Tap SOLVE to reveal, Hangman to reset<br>
-    • Double-tap top-right for Settings<br><br>
-    Tip: I emphasize that, unlike normal hangman, I don't know the word length, letter positions, or repeats.
-  </div>
-  <button id="closeHelp">Done</button>
+<button id="closeHelp">Done</button>
 </div>
 
 <script>
-const APP_VERSION="1.3.6"
-const APP_BUILD_DATE="Apr 28, 2026"
-const APP_CACHE_TOKEN="2026-04-28-5"
-const isStandalone=window.matchMedia("(display-mode: standalone)").matches||window.navigator.standalone===true
-const debugBadge=document.getElementById("debugBadge")
-let debugBadgeVisible=false
-
-// Normalize launch URL for home-screen installs so stale bookmarked query strings
-// do not lock the app to an old build on iOS standalone mode.
-{
-  const url=new URL(window.location.href)
-  const existingToken=url.searchParams.get("v")
-  if(existingToken!==APP_CACHE_TOKEN){
-    url.searchParams.set("v",APP_CACHE_TOKEN)
-    window.location.replace(url.toString())
-  }
-}
-
 const DEFAULT_LIST=["AIRFRESHENER","AIRPODS","BACKPACK","BASKET","BATHTUB","BATTERY","BED","BENCH","BLANKET","BLENDER","BOOK","BOOKEND","BOTTLE","BOWL","BRACELET","BROOM","BRUSH","BUCKET","CABINET","CALENDAR","CAMERA","CANDLE","CARDS","CARPET","CHAIR","CHARGER","CLOCK","COASTER","COMB","COMPUTER","COUCH","DESK","DOORKNOB","DRAWER","DRESSER","DUSTPAN","ENVELOPE","FRIDGE","GLASS","GLASSES","GLUE","GRATER","GUITAR","HAIRBRUSH","HAIRDRYER","HAIRTIE","HAMMER","HANGER","HEADPHONES","HEATER","HIGHLIGHTER","IRON","KETTLE","KEYBOARD","KEYS","KNIFE","LADLE","LAMP","LIGHTBULB","LIGHTER","LIPBALM","LOTION","MAGAZINE","MARKER","MATCHES","MATTRESS","MIRROR","MOP","MOUSE","MUG","NAILCLIPPERS","NAPKIN","NECKLACE","NOTEBOOK","PAN","PANTRY","PEELER","PEN","PENCIL","PERFUME","PHONE","PICTURE","PILLOW","PLANT","PLATE","PLUNGER","PRINTER","RAZOR","REMOTE","RING","ROPE","SCALE","SCISSORS","SCREWDRIVER","SHAMPOO","SHARPIE","SINK","SOAP","SPEAKER","SPATULA","SPONGE","SPOON","TABLE","TELEVISION","TISSUES","TOASTER","TOILET","TOILETPAPER","TOOLBOX","TOOTHBRUSH","TOOTHPASTE","TOWEL","TRASHCAN","TUPPERWARE","TWEEZERS","UMBRELLA","VACUUM","WALLET","WASHCLOTH","WHISK","WRENCH"]
 const CAR_BRANDS=["TOYOTA","HONDA","FORD","CHEVROLET","NISSAN","BMW","MERCEDES","AUDI","VOLKSWAGEN","HYUNDAI","KIA","SUBARU","MAZDA","TESLA","LEXUS","ACURA","INFINITI","VOLVO","JAGUAR","LANDROVER","PORSCHE","FERRARI","LAMBORGHINI","MASERATI","ALFAROMEO","FIAT","PEUGEOT","RENAULT","CITROEN","SKODA","SEAT","MINI","BENTLEY","ROLLSROYCE","ASTONMARTIN","BUGATTI","MCLAREN","GENESIS","RAM","DODGE","JEEP","CADILLAC","LINCOLN","BUICK","CHRYSLER","MITSUBISHI","SUZUKI","DAIHATSU","GEELY","TATA"]
-
-const memoryStorage={}
-const safeStorage=(()=>{
-  try{
-    const testKey="__hangman_storage_test__"
-    window.localStorage.setItem(testKey,"1")
-    window.localStorage.removeItem(testKey)
-    return window.localStorage
-  }catch{
-    return{
-      getItem:key=>Object.prototype.hasOwnProperty.call(memoryStorage,key)?memoryStorage[key]:null,
-      setItem:(key,value)=>{memoryStorage[key]=String(value)},
-      removeItem:key=>{delete memoryStorage[key]}
-    }
-  }
-})()
-
-const STORAGE_KEYS={
-  lists:"hangmanLists",
-  activeList:"hangmanActiveList",
-  exploreMode:"exploreMode",
-  debugBadge:"debugBadge"
-}
-
-const urlDebugEnabled=new URL(window.location.href).searchParams.get("debug")==="1"
-debugBadgeVisible=urlDebugEnabled||safeStorage.getItem(STORAGE_KEYS.debugBadge)==="1"
-setTimeout(()=>setDebugBadgeVisible(debugBadgeVisible),0)
-
-function readJSON(key,fallback){
-  try{
-    const value=safeStorage.getItem(key)
-    return value?JSON.parse(value):fallback
-  }catch{
-    return fallback
-  }
-}
-
-function normalizeWordArray(value,fallback){
-  if(!Array.isArray(value))return fallback.slice()
-  return Array.from(new Set(value.map(w=>String(w||"").trim().toUpperCase()).filter(Boolean)))
-}
-
-function normalizeLists(value){
-  const source=value&&typeof value==="object"?value:{}
-  const normalized={}
-  for(const [name,words] of Object.entries(source)){
-    const clean=normalizeWordArray(words,[])
-    if(clean.length)normalized[name]=clean
-  }
-  if(!normalized.default)normalized.default=DEFAULT_LIST.slice()
-  if(!normalized.cars)normalized.cars=CAR_BRANDS.slice()
-  return normalized
-}
-
-let lists=normalizeLists(readJSON(STORAGE_KEYS.lists,{}))
-safeStorage.setItem(STORAGE_KEYS.lists,JSON.stringify(lists))
-
-let currentListName=safeStorage.getItem(STORAGE_KEYS.activeList)||"default"
-
-function getWords(){
-  if(!Array.isArray(lists[currentListName])){
-    currentListName="default"
-    safeStorage.setItem(STORAGE_KEYS.activeList,currentListName)
-  }
-  return lists[currentListName]
-}
-
-const hasL=(w,ch)=>w.includes(ch)
-
+let lists=JSON.parse(localStorage.getItem("hangmanLists")||"{}")
+if(!lists.default)lists.default=DEFAULT_LIST.slice()
+if(!lists.cars)lists.cars=CAR_BRANDS.slice()
+let currentListName=localStorage.getItem("hangmanActiveList")||"default"
+if(!lists[currentListName])currentListName="default"
+function cleanWords(words){return Array.from(new Set((words||[]).map(w=>String(w).trim().toUpperCase()).filter(Boolean)))}
+function getWords(){lists[currentListName]=cleanWords(lists[currentListName]);return lists[currentListName]}
+function hasL(w,ch){return w.includes(ch)}
 function bestSplit(c){
-  const counts={}
-  for(const w of c){for(const ch of new Set(w)){counts[ch]=(counts[ch]||0)+1}}
-  const sorted=Object.entries(counts).sort((a,b)=>b[1]-a[1])
-  for(const [ch,cnt] of sorted){
-    if(cnt===0||cnt===c.length)continue
-    const yes=c.filter(w=>hasL(w,ch))
-    const no=c.filter(w=>!hasL(w,ch))
-    if(yes.length&&no.length)return{ch,yes,no}
-  }
-  return null
+const words=cleanWords(c)
+const counts={}
+for(const w of words){for(const ch of new Set(w)){counts[ch]=(counts[ch]||0)+1}}
+const sorted=Object.entries(counts).sort((a,b)=>b[1]-a[1]||a[0].localeCompare(b[0]))
+for(const [ch,cnt] of sorted){
+if(cnt===0||cnt===words.length)continue
+const yes=words.filter(w=>hasL(w,ch))
+const no=words.filter(w=>!hasL(w,ch))
+if(yes.length&&no.length)return{ch,yes,no}
 }
-
+return null
+}
 function buildTree(c){
-  if(c.length<=1)return{leaf:true,word:c[0]||null}
-  const s=bestSplit(c)
-  if(!s)return{leaf:true,word:c[0]}
-  return{leaf:false,ch:s.ch,yesNode:buildTree(s.yes),noNode:buildTree(s.no)}
+const words=cleanWords(c)
+if(words.length<=1)return{leaf:true,word:words[0]||null,words}
+const s=bestSplit(words)
+if(!s)return{leaf:true,word:words[0]||null,words}
+return{leaf:false,ch:s.ch,words,yesNode:buildTree(s.yes),noNode:buildTree(s.no)}
 }
-
-function buildRootFromList(words){
-  const split=bestSplit(words)
-  if(!split)return{leaf:true,word:words[0]}
-  return{leaf:false,ch:split.ch,yesNode:buildTree(split.yes),noNode:buildTree(split.no)}
-}
-
-function buildRoot(){return buildRootFromList(getWords())}
+function buildRoot(){return buildTree(getWords())}
 function getFirstLetter(words){const split=bestSplit(words);return split?split.ch:"?"}
-
 let root=buildRoot()
 let curNode=root
-
 const canvas=document.getElementById("drawCanvas")
 const ctx=canvas.getContext("2d")
 const btnHangman=document.getElementById("btnHangman")
 const btnClear=document.getElementById("btnClear")
 const btnUndo=document.getElementById("btnUndo")
 const btnSolve=document.getElementById("btnSolve")
-
+const peek=document.getElementById("peek")
+const perfDot=document.getElementById("perfDot")
 let DPR=window.devicePixelRatio||1
 let strokes=[]
 let currentStroke=null
 let treeHistory=[]
 let perfMode=false
 let scaffold=false
+let selectedDepth=null
 let advanceTimer=null
 let strokeGroupStartY=null
 const ADVANCE_DELAY=450
-
-function resizeCanvas(){
-  DPR=window.devicePixelRatio||1
-  const r=document.getElementById("canvasWrap").getBoundingClientRect()
-  canvas.width=r.width*DPR
-  canvas.height=r.height*DPR
-  ctx.setTransform(DPR,0,0,DPR,0,0)
-  redraw()
-  updateDebugBadge()
-}
-
-function updateDebugBadge(){
-  if(!debugBadgeVisible)return
-  const appRect=document.getElementById("app").getBoundingClientRect()
-  const canvasRect=document.getElementById("canvasWrap").getBoundingClientRect()
-  const toolbarRect=document.getElementById("toolbar").getBoundingClientRect()
-  debugBadge.textContent=`v${APP_VERSION}\napp:${Math.round(appRect.width)}x${Math.round(appRect.height)}\ncanvas:${Math.round(canvasRect.height)}\ntoolbar:${Math.round(toolbarRect.height)}`
-}
-
-function setDebugBadgeVisible(next){
-  debugBadgeVisible=!!next
-  debugBadge.classList.toggle("show",debugBadgeVisible)
-  safeStorage.setItem(STORAGE_KEYS.debugBadge,debugBadgeVisible?"1":"0")
-  updateDebugBadge()
-}
-
+function resizeCanvas(){const r=canvas.getBoundingClientRect();canvas.width=r.width*DPR;canvas.height=r.height*DPR;ctx.setTransform(DPR,0,0,DPR,0,0);redraw()}
 function drawScaffold(){
-  if(!scaffold)return
-  const W=canvas.clientWidth
-  const H=canvas.clientHeight
-  ctx.lineWidth=3
-  ctx.beginPath()
-  ctx.moveTo(W*.15,H*.55)
-  ctx.lineTo(W*.45,H*.55)
-  ctx.moveTo(W*.22,H*.55)
-  ctx.lineTo(W*.22,H*.12)
-  ctx.moveTo(W*.22,H*.12)
-  ctx.lineTo(W*.40,H*.12)
-  ctx.moveTo(W*.40,H*.12)
-  ctx.lineTo(W*.40,H*.18)
-  ctx.stroke()
+if(!scaffold)return
+const W=canvas.clientWidth
+const H=canvas.clientHeight
+ctx.lineWidth=3
+ctx.beginPath()
+ctx.moveTo(W*.15,H*.55)
+ctx.lineTo(W*.45,H*.55)
+ctx.moveTo(W*.22,H*.55)
+ctx.lineTo(W*.22,H*.12)
+ctx.moveTo(W*.22,H*.12)
+ctx.lineTo(W*.40,H*.12)
+ctx.moveTo(W*.40,H*.12)
+ctx.lineTo(W*.40,H*.18)
+ctx.stroke()
 }
-
 function redraw(){
-  const w=canvas.clientWidth
-  const h=canvas.clientHeight
-  ctx.clearRect(0,0,w,h)
-  ctx.fillStyle="#f8f4ec"
-  ctx.fillRect(0,0,w,h)
-  ctx.lineCap="round"
-  ctx.lineJoin="round"
-  drawScaffold()
-  for(const s of strokes){
-    ctx.lineWidth=s.lineWidth
-    ctx.beginPath()
-    ctx.moveTo(s.points[0][0],s.points[0][1])
-    for(let i=1;i<s.points.length;i++)ctx.lineTo(s.points[i][0],s.points[i][1])
-    ctx.stroke()
-  }
+const w=canvas.clientWidth
+const h=canvas.clientHeight
+ctx.clearRect(0,0,w,h)
+ctx.fillStyle="#f8f4ec"
+ctx.fillRect(0,0,w,h)
+ctx.lineCap="round"
+ctx.lineJoin="round"
+drawScaffold()
+for(const s of strokes){
+if(!s||!s.points||!s.points.length)continue
+ctx.lineWidth=s.lineWidth||4
+ctx.beginPath()
+ctx.moveTo(s.points[0][0],s.points[0][1])
+for(let i=1;i<s.points.length;i++)ctx.lineTo(s.points[i][0],s.points[i][1])
+ctx.stroke()
 }
-
+}
 function isYesZone(y){return y>canvas.clientHeight*.65}
-
-const peek=document.getElementById("peek")
-const perfDot=document.getElementById("perfDot")
-
 function showPeek(t){
-  if(t&&t.length===1){
-    btnSolve.textContent="Solv"+t
-  }else{
-    peek.textContent=t
-    peek.classList.add("show")
-  }
+if(t&&String(t).length===1){
+btnSolve.textContent="Solv"+t
+}else{
+peek.textContent=t||""
+peek.classList.add("show")
 }
-
+}
 function hidePeek(){
-  peek.classList.remove("show")
-  btnSolve.textContent="Solve"
+peek.classList.remove("show")
+peek.textContent=""
+btnSolve.textContent="Solve"
 }
-
 function advanceTree(isYes){if(!curNode||curNode.leaf)return;treeHistory.push(curNode);curNode=isYes?curNode.yesNode:curNode.noNode}
-
 function newSession(){strokes=[];treeHistory=[];root=buildRoot();curNode=root;perfMode=true;scaffold=true;perfDot.classList.add("show");redraw()}
-
 function clearAll(){strokes=[];treeHistory=[];perfMode=false;scaffold=false;perfDot.classList.remove("show");redraw()}
-
 function getPos(e){const r=canvas.getBoundingClientRect();const src=e.touches?e.touches[0]:e;return[src.clientX-r.left,src.clientY-r.top]}
-
 let isDrawing=false
-
 function scheduleAdvance(){
-  clearTimeout(advanceTimer)
-  advanceTimer=setTimeout(()=>{
-    const canAdvance=perfMode&&strokeGroupStartY!==null&&curNode&&!curNode.leaf
-    if(canAdvance){advanceTree(isYesZone(strokeGroupStartY))}
-    strokeGroupStartY=null
-  },ADVANCE_DELAY)
+clearTimeout(advanceTimer)
+advanceTimer=setTimeout(()=>{
+if(perfMode&&strokeGroupStartY!==null&&!curNode.leaf)advanceTree(isYesZone(strokeGroupStartY))
+strokeGroupStartY=null
+},ADVANCE_DELAY)
 }
-
 function onStart(e){
-  e.preventDefault()
-  clearTimeout(advanceTimer)
-  const[x,y]=getPos(e)
-  if(strokeGroupStartY===null)strokeGroupStartY=y
-  isDrawing=true
-  if(perfMode&&curNode){
-    if(curNode.leaf)showPeek(curNode.word||"")
-    else{
-      const nextNode=isYesZone(strokeGroupStartY)?curNode.yesNode:curNode.noNode
-      if(nextNode){
-        if(nextNode.leaf)showPeek(nextNode.word)
-        else showPeek(nextNode.ch)
-      }
-    }
-  }
-  currentStroke={points:[[x,y]],lineWidth:4}
-  ctx.lineWidth=4
-  ctx.beginPath()
-  ctx.moveTo(x,y)
+e.preventDefault()
+clearTimeout(advanceTimer)
+const[x,y]=getPos(e)
+if(strokeGroupStartY===null)strokeGroupStartY=y
+isDrawing=true
+if(perfMode){
+if(curNode.leaf)showPeek(curNode.word)
+else{
+const nextNode=isYesZone(strokeGroupStartY)?curNode.yesNode:curNode.noNode
+if(nextNode)showPeek(nextNode.leaf?nextNode.word:nextNode.ch)
 }
-
+}
+currentStroke={points:[[x,y]],lineWidth:4}
+ctx.lineWidth=4
+ctx.beginPath()
+ctx.moveTo(x,y)
+}
 function onMove(e){
-  if(!isDrawing)return
-  const[x,y]=getPos(e)
-  currentStroke.points.push([x,y])
-  ctx.lineTo(x,y)
-  ctx.stroke()
+if(!isDrawing)return
+const[x,y]=getPos(e)
+currentStroke.points.push([x,y])
+ctx.lineTo(x,y)
+ctx.stroke()
 }
-
 function onEnd(){
-  hidePeek()
-  if(!isDrawing)return
-  isDrawing=false
-  strokes.push(currentStroke)
-  scheduleAdvance()
+hidePeek()
+if(!isDrawing)return
+isDrawing=false
+strokes.push(currentStroke)
+scheduleAdvance()
 }
-
 canvas.addEventListener("touchstart",onStart,{passive:false})
 canvas.addEventListener("touchmove",onMove,{passive:false})
 canvas.addEventListener("touchend",onEnd,{passive:false})
+canvas.addEventListener("touchcancel",onEnd,{passive:false})
 canvas.addEventListener("mousedown",onStart)
 canvas.addEventListener("mousemove",e=>{if(isDrawing)onMove(e)})
 canvas.addEventListener("mouseup",onEnd)
+canvas.addEventListener("mouseleave",onEnd)
 window.addEventListener("resize",resizeCanvas)
-window.addEventListener("orientationchange",resizeCanvas)
-window.addEventListener("pageshow",resizeCanvas)
-if(window.ResizeObserver){
-  const ro=new ResizeObserver(()=>resizeCanvas())
-  ro.observe(document.getElementById("app"))
-}
 resizeCanvas()
-
-btnHangman.addEventListener("click",newSession)
-btnClear.addEventListener("click",clearAll)
-btnUndo.addEventListener("click",()=>{strokes.pop();if(treeHistory.length)curNode=treeHistory.pop();redraw()})
-
-btnSolve.addEventListener("click",()=>{
-  perfMode=false
-  hidePeek()
-  perfDot.classList.remove("show")
-  const cutoff=canvas.clientHeight*0.55
-  strokes=strokes.filter(s=>{
-    return s.points.some(p=>p[1]<=cutoff)
-  })
-  redraw()
-})
-
+btnHangman.onclick=newSession
+btnClear.onclick=clearAll
+btnUndo.onclick=()=>{if(strokes.length)strokes.pop();if(treeHistory.length)curNode=treeHistory.pop();redraw()}
+btnSolve.onclick=()=>{
+perfMode=false
+hidePeek()
+perfDot.classList.remove("show")
+const cutoff=canvas.clientHeight*.55
+strokes=strokes.filter(s=>s.points.some(p=>p[1]<=cutoff))
+redraw()
+}
 let lastTap=0
 canvas.addEventListener("pointerdown",e=>{
-  const viewW=document.documentElement.clientWidth
-  const viewH=document.documentElement.clientHeight
-  if(e.clientX>viewW*.75&&e.clientY<viewH*.25){
-    const now=Date.now()
-    if(now-lastTap<300)openSettings()
-    lastTap=now
-  }
+if(e.clientX>window.innerWidth*.75&&e.clientY<window.innerHeight*.25){
+const now=Date.now()
+if(now-lastTap<300)openSettings()
+lastTap=now
+}
 })
-
-const settingsPanel=document.getElementById("settingsPanel")
-function openSettings(){
-  settingsPanel.style.display="flex"
-  settingsPanel.setAttribute("aria-hidden","false")
-  refreshSettings()
-}
-function closeSettings(){
-  settingsPanel.style.display="none"
-  settingsPanel.setAttribute("aria-hidden","true")
-}
-document.getElementById("closeSettings").addEventListener("click",closeSettings)
-document.getElementById("settingsBuildInfo").textContent=`V${APP_VERSION} · ${APP_BUILD_DATE}${isStandalone?" · Standalone":""}`
-
+function openSettings(){document.getElementById("settingsPanel").style.display="flex";refreshSettings()}
+function closeSettings(){document.getElementById("settingsPanel").style.display="none"}
+document.getElementById("closeSettings").onclick=closeSettings
 function refreshSettings(){
-  // Sync explore mode toggle
-  document.getElementById("exploreModeToggle").checked=isExploreModeEnabled()
-  document.getElementById("debugBadgeToggle").checked=debugBadgeVisible
-  const sel=document.getElementById("listSelect")
-  sel.innerHTML=""
-  for(const k in lists){const o=document.createElement("option");o.value=k;o.textContent=k;sel.appendChild(o)}
-  sel.value=currentListName
-  renderWords()
-  renderDepthStats()
-  renderFirstLetter()
+const sel=document.getElementById("listSelect")
+sel.innerHTML=""
+for(const k in lists){const o=document.createElement("option");o.value=k;o.textContent=k;sel.appendChild(o)}
+sel.value=currentListName
+renderWords()
+renderDepthStats()
+renderFirstLetter()
+renderDepthChart()
 }
-
 function renderWords(){
-  const container=document.getElementById("wordView")
-  container.innerHTML=""
-  const words=lists[currentListName].slice().sort()
-  words.forEach(w=>{
-    const row=document.createElement("div")
-    row.className="word-row"
-    const label=document.createElement("span")
-    label.textContent=w
-    const btn=document.createElement("button")
-    btn.textContent="×"
-    btn.className="word-delete-btn"
-    btn.setAttribute("aria-label","Remove word "+w)
-    btn.addEventListener("click",()=>{
-      lists[currentListName]=lists[currentListName].filter(x=>x!==w)
-      safeStorage.setItem(STORAGE_KEYS.lists,JSON.stringify(lists))
-      root=buildRoot()
-      curNode=root
-      refreshSettings()
-    })
-    row.appendChild(label)
-    row.appendChild(btn)
-    container.appendChild(row)
-  })
+const box=document.getElementById("wordView")
+box.innerHTML=""
+const words=getWords()
+words.forEach(w=>{
+const row=document.createElement("div")
+row.style.display="flex"
+row.style.justifyContent="space-between"
+row.style.alignItems="center"
+row.style.gap="8px"
+row.style.borderBottom="1px solid #eee"
+row.style.padding="3px 0"
+const word=document.createElement("span")
+word.textContent=w
+const remove=document.createElement("button")
+remove.textContent="Remove"
+remove.style.fontFamily="monospace"
+remove.style.fontSize="11px"
+remove.style.padding="2px 6px"
+remove.onclick=()=>{
+lists[currentListName]=getWords().filter(x=>x!==w)
+localStorage.setItem("hangmanLists",JSON.stringify(lists))
+root=buildRoot()
+curNode=root
+strokes=[]
+treeHistory=[]
+selectedDepth=null
+redraw()
+refreshSettings()
 }
-
-function renderFirstLetter(){const letter=getFirstLetter(lists[currentListName]);document.getElementById("firstLetter").textContent="First Letter: "+letter}
-
-function depthCount(node,depth,counts){if(!node)return;if(node.leaf){counts[depth]=(counts[depth]||0)+1;return}depthCount(node.yesNode,depth+1,counts);depthCount(node.noNode,depth+1,counts)}
-
+row.appendChild(word)
+row.appendChild(remove)
+box.appendChild(row)
+})
+}
+function renderFirstLetter(){document.getElementById("firstLetter").textContent="First Letter: "+getFirstLetter(getWords())}
+function collectWordsByDepth(node,depth,map){
+if(!node)return
+if(node.leaf){
+if(!map[depth])map[depth]=[]
+if(node.word)map[depth].push(node.word)
+return
+}
+collectWordsByDepth(node.yesNode,depth+1,map)
+collectWordsByDepth(node.noNode,depth+1,map)
+}
+function getWordsByDepth(){
+const map={}
+collectWordsByDepth(buildRoot(),0,map)
+for(const d in map)map[d].sort()
+return map
+}
 function renderDepthStats(){
-  const counts={}
-  const r=buildRoot()
-  depthCount(r,0,counts)
-  let html=""
-  const depths=Object.keys(counts).sort((a,b)=>a-b)
-  for(const d of depths){html+="Depth "+d+": "+counts[d]+" words<br>"}
-  document.getElementById("depthStats").innerHTML=html
+const map=getWordsByDepth()
+const depths=Object.keys(map).map(Number).sort((a,b)=>a-b)
+const total=getWords().length
+if(!depths.length){document.getElementById("depthStats").innerHTML="No words in list.";return}
+const min=depths[0]
+const max=depths[depths.length-1]
+const sum=depths.reduce((acc,d)=>acc+d*map[d].length,0)
+const avg=(sum/total).toFixed(1)
+document.getElementById("depthStats").innerHTML="Words: "+total+"<br>Shortest path: "+min+" letters<br>Longest path: "+max+" letters<br>Average path: "+avg+" letters"
 }
-
-const listSelect=document.getElementById("listSelect")
-const useList=document.getElementById("useList")
-const addWordInput=document.getElementById("addWordInput")
-const createListBtn=document.getElementById("createListBtn")
-
-useList.addEventListener("click",()=>{
-  currentListName=listSelect.value
-  safeStorage.setItem(STORAGE_KEYS.activeList,currentListName)
-  root=buildRoot()
-  curNode=root
-  refreshSettings()
+function collectWordPaths(node,path,out){
+if(!node)return
+if(node.leaf){
+if(node.word)out.push({word:node.word,path:path.slice()})
+return
+}
+collectWordPaths(node.yesNode,path.concat({ch:node.ch,yes:true}),out)
+collectWordPaths(node.noNode,path.concat({ch:node.ch,yes:false}),out)
+}
+function getWordPaths(){
+const out=[]
+collectWordPaths(buildRoot(),[],out)
+out.sort((a,b)=>a.word.localeCompare(b.word))
+return out
+}
+function maxNoRunBeforeYes(path){
+let run=0
+let max=0
+for(const step of path){
+if(step.yes){
+run=0
+}else{
+run++
+if(run>max)max=run
+}
+}
+return max
+}
+function totalNoCount(path){return path.filter(step=>!step.yes).length}
+function totalYesCount(path){return path.filter(step=>step.yes).length}
+function renderPatternFilter(){
+const paths=getWordPaths()
+const noInput=document.getElementById("noRunFilter")
+const yesInput=document.getElementById("yesCountFilter")
+const wordsBox=document.getElementById("patternWords")
+function update(){
+const noRaw=noInput.value.trim()
+const yesRaw=yesInput.value.trim()
+const noVal=noRaw===""?null:Number(noRaw)
+const yesVal=yesRaw===""?null:Number(yesRaw)
+const matches=paths.filter(p=>{
+const noRun=maxNoRunBeforeYes(p.path)
+const yesCount=totalYesCount(p.path)
+return (noVal===null||noRun===noVal)&&(yesVal===null||yesCount===yesVal)
 })
-
-addWordInput.addEventListener("keydown",e=>{
-  if(e.key!="Enter")return
-  const w=e.target.value.trim().toUpperCase()
-  if(!w)return
-  if(!lists[currentListName].includes(w))lists[currentListName].push(w)
-  safeStorage.setItem(STORAGE_KEYS.lists,JSON.stringify(lists))
-  root=buildRoot()
-  curNode=root
-  strokes=[]
-  treeHistory=[]
-  redraw()
-  e.target.value=""
-  refreshSettings()
+let header="<b>Matches: "+matches.length+"</b>"
+if(noVal!==null)header+="<br>Max consecutive incorrect guesses / NOs: "+noVal
+if(yesVal!==null)header+="<br>Total correct letters / YESes: "+yesVal
+wordsBox.innerHTML=header+"<br>"
+if(!matches.length){wordsBox.innerHTML+="No words match those filters.";return}
+matches.forEach(p=>{
+const chip=document.createElement("span")
+chip.className="depthWordChip"
+chip.textContent=p.word+" (max NO streak "+maxNoRunBeforeYes(p.path)+", total NO "+totalNoCount(p.path)+", YES "+totalYesCount(p.path)+")"
+wordsBox.appendChild(chip)
 })
-
-createListBtn.addEventListener("click",()=>{
-  const name=document.getElementById("newListName").value.trim()
-  const raw=document.getElementById("newListWords").value
-  if(!name||!raw)return
-  const words=raw.split("\n").map(w=>w.trim().toUpperCase()).filter(w=>w.length>0)
-  if(words.length===0)return
-  lists[name]=Array.from(new Set(words))
-  safeStorage.setItem(STORAGE_KEYS.lists,JSON.stringify(lists))
-  document.getElementById("newListName").value=""
-  document.getElementById("newListWords").value=""
-  refreshSettings()
+}
+noInput.oninput=update
+yesInput.oninput=update
+update()
+}
+function renderDepthChart(){
+const chart=document.getElementById("depthChart")
+const wordsBox=document.getElementById("depthWords")
+const map=getWordsByDepth()
+const depths=Object.keys(map).map(Number).sort((a,b)=>a-b)
+chart.innerHTML=""
+if(!depths.length){
+chart.textContent="No words to chart."
+wordsBox.textContent="Add words to see distribution."
+renderPatternFilter()
+return
+}
+const intro=document.createElement("div")
+intro.className="chartIntro"
+intro.textContent="Path length distribution: how many yes/no letter questions it takes to reach each word. Tap a bar to see the words at that depth."
+chart.appendChild(intro)
+const maxCount=Math.max(...depths.map(d=>map[d].length))
+depths.forEach(d=>{
+const row=document.createElement("div")
+row.className="depthBarRow"+(selectedDepth===d?" selected":"")
+const label=document.createElement("div")
+label.className="depthLabel"
+label.textContent=d+" letters"
+const track=document.createElement("div")
+track.className="depthBarTrack"
+const bar=document.createElement("div")
+bar.className="depthBar"
+bar.style.width=(map[d].length/maxCount*100)+"%"
+track.appendChild(bar)
+const count=document.createElement("div")
+count.className="depthCount"
+count.textContent=map[d].length
+row.appendChild(label)
+row.appendChild(track)
+row.appendChild(count)
+row.onclick=()=>{selectedDepth=d;renderDepthChart()}
+chart.appendChild(row)
 })
-
-// ── Explore List Mode ──────────────────────────────────────────────
-
-let exploreHistory=[]
-let exploreNode=null
-let exploreWords=[]
-
-const EXPLORE_ON="1"
-function isExploreModeEnabled(){return safeStorage.getItem(STORAGE_KEYS.exploreMode)===EXPLORE_ON}
-
-function pluralWords(n){return n+" word"+(n!==1?"s":"")}
-function syncExploreButton(){
-  document.getElementById("btnExplore").style.display=isExploreModeEnabled()?"":"none"
-}
-
-const exploreModeToggle=document.getElementById("exploreModeToggle")
-exploreModeToggle.checked=isExploreModeEnabled()
-exploreModeToggle.addEventListener("change",()=>{
-  safeStorage.setItem(STORAGE_KEYS.exploreMode,exploreModeToggle.checked?EXPLORE_ON:"0")
-  syncExploreButton()
+if(selectedDepth===null||!map[selectedDepth])selectedDepth=depths[0]
+const selectedWords=map[selectedDepth]||[]
+wordsBox.innerHTML="<b>Depth "+selectedDepth+" ("+selectedWords.length+" words)</b><br>"
+selectedWords.forEach(w=>{
+const chip=document.createElement("span")
+chip.className="depthWordChip"
+chip.textContent=w
+wordsBox.appendChild(chip)
 })
-const debugBadgeToggle=document.getElementById("debugBadgeToggle")
-debugBadgeToggle.checked=debugBadgeVisible
-debugBadgeToggle.addEventListener("change",()=>setDebugBadgeVisible(debugBadgeToggle.checked))
-syncExploreButton()
-
-const explorePanel=document.getElementById("explorePanel")
-function openExplore(){
-  exploreHistory=[]
-  exploreNode=root
-  exploreWords=getWords().slice()
-  renderExplore()
-  explorePanel.style.display="flex"
-  explorePanel.setAttribute("aria-hidden","false")
+renderPatternFilter()
 }
-
-function closeExplore(){
-  explorePanel.style.display="none"
-  explorePanel.setAttribute("aria-hidden","true")
+document.getElementById("useList").onclick=()=>{
+const selected=document.getElementById("listSelect").value
+if(!lists[selected])return
+currentListName=selected
+localStorage.setItem("hangmanActiveList",currentListName)
+root=buildRoot()
+curNode=root
+selectedDepth=null
+refreshSettings()
 }
-
-function renderExplore(){
-  const node=exploreNode
-  const words=exploreWords
-
-  // Breadcrumb path
-  const pathEl=document.getElementById("explorePath")
-  if(exploreHistory.length===0){
-    pathEl.textContent=""
-  } else {
-    pathEl.innerHTML=exploreHistory.map(h=>`<span class="path-item ${h.yes?'yes':'no'}">${h.ch}${h.yes?'✓':'✗'}</span>`).join('<span class="path-sep">→</span>')
-  }
-
-  const questionEl=document.getElementById("exploreQuestion")
-  const branchesEl=document.getElementById("exploreBranches")
-  const leafCard=document.getElementById("exploreLeafCard")
-
-  if(node.leaf){
-    questionEl.style.display="none"
-    branchesEl.style.display="none"
-    leafCard.style.display="block"
-    document.getElementById("exploreLeafWord").textContent=node.word||"(none)"
-  } else {
-    leafCard.style.display="none"
-    questionEl.style.display="block"
-    questionEl.textContent='Contains “'+node.ch+'”?'
-    branchesEl.style.display="flex"
-
-    const yesWords=words.filter(w=>w.includes(node.ch))
-    const noWords=words.filter(w=>!w.includes(node.ch))
-
-    // YES card
-    document.getElementById("exploreYesCount").textContent=pluralWords(yesWords.length)
-    if(node.yesNode.leaf){
-      document.getElementById("exploreYesNext").textContent=""
-      document.getElementById("exploreYesLeaf").textContent=node.yesNode.word||"(none)"
-    } else {
-      document.getElementById("exploreYesNext").textContent="→ "+node.yesNode.ch+"?"
-      document.getElementById("exploreYesLeaf").textContent=""
-    }
-
-    // NO card
-    document.getElementById("exploreNoCount").textContent=pluralWords(noWords.length)
-    if(node.noNode.leaf){
-      document.getElementById("exploreNoNext").textContent=""
-      document.getElementById("exploreNoLeaf").textContent=node.noNode.word||"(none)"
-    } else {
-      document.getElementById("exploreNoNext").textContent="→ "+node.noNode.ch+"?"
-      document.getElementById("exploreNoLeaf").textContent=""
-    }
-  }
-
-  // Word list
-  const header=document.getElementById("exploreWordsHeader")
-  const grid=document.getElementById("exploreWordsGrid")
-  header.textContent=pluralWords(words.length)+" remaining"
-  grid.innerHTML=words.slice().sort().map(w=>`<span class="explore-word">${w}</span>`).join("")
-}
-
-const exploreBackBtn=document.getElementById("exploreBack")
-const exploreYesCard=document.getElementById("exploreYesCard")
-const exploreNoCard=document.getElementById("exploreNoCard")
-
-document.getElementById("btnExplore").addEventListener("click",openExplore)
-document.getElementById("exploreClose").addEventListener("click",closeExplore)
-
-exploreBackBtn.addEventListener("click",()=>{
-  if(exploreHistory.length===0){closeExplore();return}
-  exploreHistory.pop()
-  // Replay from root
-  exploreNode=root
-  exploreWords=getWords().slice()
-  for(const h of exploreHistory){
-    if(h.yes){
-      exploreWords=exploreWords.filter(w=>w.includes(exploreNode.ch))
-      exploreNode=exploreNode.yesNode
-    } else {
-      exploreWords=exploreWords.filter(w=>!w.includes(exploreNode.ch))
-      exploreNode=exploreNode.noNode
-    }
-  }
-  renderExplore()
+document.getElementById("addWordInput").addEventListener("keydown",e=>{
+if(e.key!=="Enter")return
+const w=e.target.value.trim().toUpperCase()
+if(!w)return
+if(!getWords().includes(w))lists[currentListName].push(w)
+localStorage.setItem("hangmanLists",JSON.stringify(lists))
+root=buildRoot()
+curNode=root
+strokes=[]
+treeHistory=[]
+selectedDepth=null
+redraw()
+e.target.value=""
+refreshSettings()
 })
-
-function stepExplore(yes){
-  if(!exploreNode||exploreNode.leaf)return
-  exploreHistory.push({ch:exploreNode.ch,yes})
-  exploreWords=exploreWords.filter(w=>yes?w.includes(exploreNode.ch):!w.includes(exploreNode.ch))
-  exploreNode=yes?exploreNode.yesNode:exploreNode.noNode
-  renderExplore()
+document.getElementById("createListBtn").onclick=()=>{
+const name=document.getElementById("newListName").value.trim()
+const raw=document.getElementById("newListWords").value
+if(!name||!raw)return
+const words=cleanWords(raw.split("\n"))
+if(!words.length)return
+lists[name]=words
+currentListName=name
+localStorage.setItem("hangmanLists",JSON.stringify(lists))
+localStorage.setItem("hangmanActiveList",currentListName)
+document.getElementById("newListName").value=""
+document.getElementById("newListWords").value=""
+root=buildRoot()
+curNode=root
+selectedDepth=null
+refreshSettings()
 }
-
-function bindActivatableCard(el,handler){
-  el.addEventListener("click",handler)
-  el.addEventListener("keydown",e=>{
-    if(e.key==="Enter"||e.key===" "){
-      e.preventDefault()
-      handler()
-    }
-  })
-}
-bindActivatableCard(exploreYesCard,()=>stepExplore(true))
-bindActivatableCard(exploreNoCard,()=>stepExplore(false))
-</script><script>
 const helpOverlay=document.getElementById('helpOverlay')
 let helpTap=0
 canvas.addEventListener('pointerdown',e=>{
-  const viewW=document.documentElement.clientWidth
-  const viewH=document.documentElement.clientHeight
-  if(e.clientX<viewW*.25&&e.clientY<viewH*.25){
-    const now=Date.now()
-    if(now-helpTap<300){helpOverlay.style.display='block';helpOverlay.setAttribute("aria-hidden","false")}
-    helpTap=now
-  }
+if(e.clientX<window.innerWidth*.25&&e.clientY<window.innerHeight*.25){
+const now=Date.now()
+if(now-helpTap<300)helpOverlay.style.display='block'
+helpTap=now
+}
 })
-document.getElementById("closeHelp").addEventListener("click",()=>{helpOverlay.style.display='none';helpOverlay.setAttribute("aria-hidden","true")})
+document.getElementById('closeHelp').onclick=()=>helpOverlay.style.display='none'
 </script>
-
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Bring the codebase up to the new Hangman implementation that improves single-canvas input, peek/solve behavior, and stroke-driven yes/no advancement. 
- Expose decision-tree insights (path depth distribution and per-depth word drilldowns) so word lists can be analyzed and tuned. 
- Simplify storage and session flow so performance-mode, scaffold display, and solve/undo interactions behave more predictably.

### Description
- Replaced the contents of `hangman.html` with the provided updated implementation and integrated the new single-canvas layout and toolbar controls. 
- Reworked the decision-tree logic with the consolidated `bestSplit`, `buildTree` and `buildRoot` flow and added utilities for collecting word paths and depth statistics. 
- Added settings/analytics UI: an Anagram Depth Distribution chart, per-depth word drilldown, and a pattern filter (max NO run / YES count), and updated the settings and help overlays. 
- Updated canvas handling and interaction logic, including `resizeCanvas`, stroke grouping with `ADVANCE_DELAY`, `isYesZone`, `showPeek`/`hidePeek`, `newSession`/`clearAll`/`btnSolve` behaviors, and simplified persistence to `localStorage`.

### Testing
- No automated tests were executed because this is a static HTML/JS update. 
- Validated that the updated file was written to `./hangman.html` and inspected the resulting file contents with `nl -ba` to confirm the expected changes were applied. 
- Confirmed the repository contains the updated `hangman.html` and the working tree reflects the applied changes (diff inspected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2065fb97083329d55054dbf6fae3a)