### PR TITLE
Fix canvas/toolbar layout on mobile viewport resize

### DIFF
--- a/hangman.html
+++ b/hangman.html
@@ -8,10 +8,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;600;700&family=Space+Mono:wght@400;700&display=swap');
 :root{--bg:#f4efe6;--paper:#f8f4ec;--ink:#1a1814;--faint:#cfc6b6;--toolbar:#ece6dc}
 *{box-sizing:border-box;-webkit-tap-highlight-color:transparent;margin:0;padding:0}
-html,body{height:100%;width:100%;overflow:hidden;font-family:'Caveat',cursive;background:#ddd}
-#frame{position:fixed;inset:0;padding:10px;background:#e9e3d7}
-#app{width:100%;height:100%;display:flex;flex-direction:column;background:var(--bg);border-radius:10px;border:2px solid rgba(0,0,0,.35);box-shadow:0 4px 12px rgba(0,0,0,.12);position:relative;overflow:hidden}
-#drawCanvas{flex:1;width:100%;display:block;cursor:crosshair;touch-action:none;background:linear-gradient(var(--paper),var(--paper))}
+html,body{height:100%;width:100%;overflow:hidden;font-family:'Caveat',cursive;background:var(--bg)}
+#frame{position:fixed;inset:0;height:100dvh;padding:10px;background:#e9e3d7}
+#app{width:100%;height:100%;min-height:0;display:flex;flex-direction:column;background:var(--bg);border-radius:10px;border:2px solid rgba(0,0,0,.35);box-shadow:0 4px 12px rgba(0,0,0,.12);position:relative;overflow:hidden}
+#drawCanvas{flex:1;min-height:0;width:100%;display:block;cursor:crosshair;touch-action:none;background:linear-gradient(var(--paper),var(--paper))}
 #toolbar{height:56px;background:linear-gradient(var(--toolbar),#e6dfd3);border-top:1px solid var(--faint);display:flex;align-items:center;justify-content:space-around;padding:0 8px;flex-shrink:0}
 .tool-btn{font-family:'Space Mono',monospace;font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;background:#f7f2e8;border:1px solid var(--faint);border-radius:10px;padding:7px 13px;color:#6f6a61;cursor:pointer}
 .tool-btn.active{background:var(--ink);color:#fff8ee;border-color:var(--ink)}
@@ -290,6 +290,7 @@ canvas.addEventListener("mousemove",e=>{if(isDrawing)onMove(e)})
 canvas.addEventListener("mouseup",onEnd)
 canvas.addEventListener("mouseleave",onEnd)
 window.addEventListener("resize",resizeCanvas)
+if(window.visualViewport)window.visualViewport.addEventListener("resize",resizeCanvas)
 resizeCanvas()
 btnHangman.onclick=newSession
 btnClear.onclick=clearAll


### PR DESCRIPTION
### Motivation
- Mobile browser viewport chrome changes could leave a blank strip at the bottom and push the toolbar offscreen, causing buttons to disappear and not recover.
- The canvas flex sizing and reliance only on `window.resize` prevented reliable recalculation of the drawing area when the visual viewport changed.

### Description
- Use the app background variable by changing `html,body` background to `var(--bg)` and set `#frame` to `height:100dvh` to track dynamic viewport height.
- Allow flex children to shrink by adding `min-height:0` to `#app` and `#drawCanvas` so the toolbar is not pushed out of view.
- Add a `visualViewport.resize` listener (in addition to `window.resize`) and call `resizeCanvas()` to recalc canvas dimensions on mobile viewport changes.

### Testing
- Ran `git diff -- hangman.html`, `git status --short`, and committed the change with `git commit -m "Fix canvas/toolbar layout on mobile viewport resize"`, all of which completed successfully.
- There are no automated unit tests in the repository, so the fix was validated via code review and the produced diff/commit checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20fd6f8d08332bb68d0866c627731)